### PR TITLE
Include uppercase options when matching

### DIFF
--- a/src/AutoCompleteTextField.jsx
+++ b/src/AutoCompleteTextField.jsx
@@ -139,7 +139,7 @@ class AutocompleteTextField extends React.Component {
       if (matchStart >= 0) {
         const matchedSlug = str.substring(matchStart, caret);
         const options = providedOptions.filter((slug) => {
-          const idx = slug.indexOf(matchedSlug);
+          const idx = slug.toLowerCase().indexOf(matchedSlug);
           return idx !== -1 && (matchAny || idx === 0);
         });
 

--- a/test/AutoCompleteTextField.spec.js
+++ b/test/AutoCompleteTextField.spec.js
@@ -143,6 +143,13 @@ describe('option list filtering', () => {
     component.find('textarea').simulate('change', createOnChangeEvent('@ABC'));
     expect(component.find('.react-autocomplete-input > li')).to.have.length(3);
   });
+
+  it('abc => 3 options including one uppercase', () => {
+    const component = mount(<TextField trigger="@" options={["aa", "ab", "abc", "abcd", "ABCDE"]} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@abc'));
+    expect(component.find('.react-autocomplete-input > li')).to.have.length(3);
+  });
 });
 
 describe('max options test', () => {

--- a/test/AutoCompleteTextField.spec.js
+++ b/test/AutoCompleteTextField.spec.js
@@ -137,6 +137,12 @@ describe('option list filtering', () => {
     expect(component.find('.react-autocomplete-input > li')).to.have.length(2);
   });
 
+  it('ABC => 3 options', () => {
+    const component = mount(<TextField trigger="@" options={["aa", "ab", "abc", "abcd", "ABCDE"]} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@ABC'));
+    expect(component.find('.react-autocomplete-input > li')).to.have.length(3);
+  });
 });
 
 describe('max options test', () => {


### PR DESCRIPTION

## Before
'l' or 'L' does not match the option 'LOWER'
![screencast 2018-02-22 17-17](https://user-images.githubusercontent.com/1263717/36520241-c6303f92-17f4-11e8-84d1-1ca6a2e81449.gif)

## After
'T' matches 'tag' or 'TAG'
![screencast 2018-02-22 17-20_1](https://user-images.githubusercontent.com/1263717/36520240-c18272f8-17f4-11e8-8f7c-32905c14b916.gif)

