### PR TITLE
Auto build on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/bundle.js",
   "scripts": {
     "build": "NODE_ENV=production webpack -p",
+    "install": "npm run build",
     "clean": "rimraf dist coverage lib",
     "lint": "eslint src --ext .js,.jsx",
     "test": "mocha --compilers js:babel-core/register",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/bundle.js",
   "scripts": {
     "build": "NODE_ENV=production webpack -p",
-    "install": "npm run build",
+    "postinstall": "npm run build",
     "clean": "rimraf dist coverage lib",
     "lint": "eslint src --ext .js,.jsx",
     "test": "mocha --compilers js:babel-core/register",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/bundle.js",
   "scripts": {
     "build": "NODE_ENV=production webpack -p",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "clean": "rimraf dist coverage lib",
     "lint": "eslint src --ext .js,.jsx",
     "test": "mocha --compilers js:babel-core/register",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/bundle.js",
   "scripts": {
     "build": "NODE_ENV=production webpack -p",
-    "prepare": "npm run build",
+    "prepublish": "npm run build",
     "clean": "rimraf dist coverage lib",
     "lint": "eslint src --ext .js,.jsx",
     "test": "mocha --compilers js:babel-core/register",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/bundle.js",
   "scripts": {
     "build": "NODE_ENV=production webpack -p",
-    "postinstall": "npm run build",
+    "prepare": "npm run build",
     "clean": "rimraf dist coverage lib",
     "lint": "eslint src --ext .js,.jsx",
     "test": "mocha --compilers js:babel-core/register",


### PR DESCRIPTION
Since we're temporarily using the Optimal Workshop version of this library we're not using the yarn prepackaged version, which already has been "built" (compiled and put into a "dist" folder).

So we need to run the build script ourselves, after it's been installed by yarn. To do this we add a prepare hook in `package.json`. It's a one-liner.

